### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ This repository contains a simple go app. You do not need to know go, nor use an
 
           # Install go 1.21
           - name: Setup go
-            uses: actions/setup-go@v4
+            uses: actions/setup-go@v5
             with: # Specify input variables to the action
               go-version: '1.21.x'
 


### PR DESCRIPTION
Feilmelding fra `actionlint`: `the runner of "actions/setup-go@v4" action is too old to run on GitHub Actions. update the action's version to fix this issue`

Oppdaterer derfor action-versjon for setup-go i README til v5.